### PR TITLE
ComdorYamlInput, Mention.comdorYaml() and unit tests

### DIFF
--- a/src/main/java/co/comdor/github/ComdorYaml.java
+++ b/src/main/java/co/comdor/github/ComdorYaml.java
@@ -36,7 +36,6 @@ import java.util.List;
  * @todo #27:30min Design and implement "aliases", which will basically be
  *  customized commands, aliases, labels for scripts which the users may want
  *  to execute periodically, like merging or deploying scripts.
- * @todo #27:30min Add an implementation based on camel library.
  */
 public interface ComdorYaml {
     

--- a/src/main/java/co/comdor/github/ComdorYamlInput.java
+++ b/src/main/java/co/comdor/github/ComdorYamlInput.java
@@ -1,0 +1,67 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package co.comdor.github;
+
+import com.amihaiemil.camel.Yaml;
+import com.amihaiemil.camel.YamlMapping;
+import com.amihaiemil.camel.YamlSequence;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CcmdorYaml from InputStream.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.2
+ */
+public final class ComdorYamlInput implements ComdorYaml {
+
+    /**
+     * Contents of .comdor.yml.
+     */
+    private final YamlMapping yaml;
+
+    /**
+     * Ctor.
+     * @param yaml .charles.yml.
+     * @throws IOException If the input stream cannot be read.
+     */
+    public ComdorYamlInput(final InputStream yaml) throws IOException {
+        this.yaml = Yaml.createYamlInput(yaml).readYamlMapping();
+    }
+    
+    @Override
+    public String docker() {
+        return this.yaml.string("docker");
+    }
+
+    @Override
+    public List<String> architects() {
+        final List<String> architects = new ArrayList<>();
+        final YamlSequence sequence = this.yaml.yamlSequence("architects");
+        if(sequence != null) {
+            for(int idx=0; idx<sequence.size(); idx = idx + 1) {
+                architects.add(sequence.string(idx));
+            }
+        }
+        return architects;
+    }
+
+    @Override
+    public List<String> commanders() {
+        final List<String> commanders = new ArrayList<>();
+        final YamlSequence sequence = this.yaml.yamlSequence("commanders");
+        if(sequence != null) {
+            for(int idx=0; idx<sequence.size(); idx = idx + 1) {
+                commanders.add(sequence.string(idx));
+            }
+        }
+        return commanders;
+    }
+    
+}

--- a/src/main/java/co/comdor/github/JsonMention.java
+++ b/src/main/java/co/comdor/github/JsonMention.java
@@ -25,7 +25,9 @@
  */
 package co.comdor.github;
 
+import com.jcabi.github.Content;
 import com.jcabi.github.Issue;
+import java.io.ByteArrayInputStream;
 
 import javax.json.JsonObject;
 import java.io.IOException;
@@ -47,12 +49,12 @@ public abstract class JsonMention implements Mention {
      * Github issue Comment in Json format.
      * @see https://developer.github.com/v3/issues/comments/
      */
-    private JsonObject json;
+    private final JsonObject json;
 
     /**
      * Issue where the mention was found.
      */
-    private Issue issue;
+    private final Issue issue;
 
     /**
      * Ctor.
@@ -70,6 +72,25 @@ public abstract class JsonMention implements Mention {
     @Override
     public abstract Language language();
 
+    @Override
+    public final ComdorYaml comdorYaml() throws IOException {
+        final ComdorYaml yaml;
+        if(this.issue.repo().contents().exists(".comdor.yml", "master")) {
+            yaml = new ComdorYamlInput(
+                new ByteArrayInputStream(
+                    new Content.Smart(
+                        this.issue.repo()
+                            .contents()
+                            .get(".comdor.yml")
+                    ).decoded()
+                )
+            );
+        } else {
+            yaml = new ComdorYaml.Missing();
+        }
+        return yaml;
+    }
+    
     @Override
     public abstract void understand(final Language... langs) throws IOException;
 

--- a/src/main/java/co/comdor/github/Mention.java
+++ b/src/main/java/co/comdor/github/Mention.java
@@ -69,6 +69,14 @@ public interface Mention {
     Issue issue();
 
     /**
+     * Comdor.yml file present in the repository's root, which contains
+     * configurations.
+     * @return ComdorYaml
+     * @throws IOException If .comdor.yml cannot be read from the repository.
+     */
+    ComdorYaml comdorYaml() throws IOException;
+    
+    /**
      * Reply to this mention.
      * @param message Message of the reply.
      * @throws IOException If the comment cannot be sent to Github.

--- a/src/test/java/co/comdor/github/ComdorYamlInputTestCase.java
+++ b/src/test/java/co/comdor/github/ComdorYamlInputTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package co.comdor.github;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ComdorYamlInput}.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 0.0.2
+ */
+public final class ComdorYamlInputTestCase {
+    
+    /**
+     * ComdorYamlInput can read the commanders list.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void readsCommanders() throws IOException {
+        final ComdorYaml comdor = new ComdorYamlInput(
+            new ByteArrayInputStream(
+                "docker: a/b\ncommanders:\n  - john\n  - amihaiemil".getBytes()
+            )
+        );
+        final List<String> commanders = comdor.commanders();
+        MatcherAssert.assertThat(commanders, Matchers.hasSize(2));
+        MatcherAssert.assertThat(
+            commanders.get(0), Matchers.equalTo("amihaiemil")
+        );
+        MatcherAssert.assertThat(
+            commanders.get(1), Matchers.equalTo("john")
+        );
+    }
+    
+    /**
+     * ComdorYamlInput can read the architects list.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void readsArchitects() throws IOException {
+        final ComdorYaml comdor = new ComdorYamlInput(
+            new ByteArrayInputStream(
+                "docker: c/d\narchitects:\n  - john\n  - amihaiemil".getBytes()
+            )
+        );
+        final List<String> architects = comdor.architects();
+        MatcherAssert.assertThat(architects, Matchers.hasSize(2));
+        MatcherAssert.assertThat(
+            architects.get(0), Matchers.equalTo("amihaiemil")
+        );
+        MatcherAssert.assertThat(
+            architects.get(1), Matchers.equalTo("john")
+        );
+    }
+    
+    /**
+     * Reads the docker attribute.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void readsDocker() throws IOException {
+        final ComdorYaml comdor = new ComdorYamlInput(
+            new ByteArrayInputStream(
+                "docker: amihaiemil/java9".getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            comdor.docker(), Matchers.equalTo("amihaiemil/java9")
+        );
+    }
+    
+    /**
+     * Docker attribute is missing, so ComdorYamlInput returns null.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void missingDocker() throws IOException {
+        final ComdorYaml comdor = new ComdorYamlInput(
+            new ByteArrayInputStream(
+                "commanders:\n  - somone".getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            comdor.docker(), Matchers.equalTo(null)
+        );
+    }
+    
+    /**
+     * The commanders' list is missing, so ComdorYamlInput returns an
+     * empty list.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void missingCommanders() throws IOException {
+        final ComdorYaml comdor = new ComdorYamlInput(
+            new ByteArrayInputStream(
+                "architects:\n  - somone".getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            comdor.commanders(), Matchers.iterableWithSize(0)
+        );
+    }
+    
+    /**
+     * The architects' list is missing, so ComdorYamlInput returns an
+     * empty list.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void missingArchitects() throws IOException {
+        final ComdorYaml comdor = new ComdorYamlInput(
+            new ByteArrayInputStream(
+                "docker: a/b".getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            comdor.architects(), Matchers.iterableWithSize(0)
+        );
+    }
+}


### PR DESCRIPTION
Added ComdorYamlInput which represents the .comdor.yml as InputStream read from the repo. It turns the InputStream into a YamlMapping and reads the data from there.

Also added Mention.comdorYaml() which returns the .comdor.yml of the repo where the Mention has been detected.

Added unit tests for everything.