### PR TITLE
Let the Docker host provide a random name

### DIFF
--- a/src/main/java/co/comdor/DockerHost.java
+++ b/src/main/java/co/comdor/DockerHost.java
@@ -46,10 +46,9 @@ public interface DockerHost {
     /**
      * Create a container based on the given image.
      * @param image Docker image.
-     * @param name Name of the container.
      * @return The created Container.
      */
-    Container create(final String image, final String name);
+    Container create(final String image);
 
     /**
      * Start a container.

--- a/src/main/java/co/comdor/FireUpDocker.java
+++ b/src/main/java/co/comdor/FireUpDocker.java
@@ -34,8 +34,6 @@ import java.io.IOException;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.3
- * @todo #68:30min Command should return the name for the Docker container
- *  (e.g. repo/name#22). Right now the name is hardcoded to "test".
  */
 public final class FireUpDocker extends IntermediaryStep {
 
@@ -83,9 +81,7 @@ public final class FireUpDocker extends IntermediaryStep {
         try(
             final Container container = this.host
                 .connect()
-                .create(
-                    command.comdorYaml().docker(), "test"
-                ).start()
+                .create(command.comdorYaml().docker()).start()
         ) {
             container.execute(command.scripts(), log.logger());
         }

--- a/src/main/java/co/comdor/RtDockerHost.java
+++ b/src/main/java/co/comdor/RtDockerHost.java
@@ -40,8 +40,6 @@ import java.nio.file.Paths;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.3
- * @todo #58:30min Add a Decorator which catches all the checked exceptions,
- *  logs them and throws a RuntimeException further.
  */
 public final class RtDockerHost implements DockerHost{
 

--- a/src/main/java/co/comdor/RtDockerHost.java
+++ b/src/main/java/co/comdor/RtDockerHost.java
@@ -123,7 +123,7 @@ public final class RtDockerHost implements DockerHost{
     }
     
     @Override
-    public Container create(final String image, final String name) {
+    public Container create(final String image) {
         if(this.client == null) {
             throw new IllegalStateException(
                 "Not connected. Don't forget to get a connected "
@@ -136,14 +136,13 @@ public final class RtDockerHost implements DockerHost{
                 ContainerConfig
                     .builder()
                     .image(image)
-                    .build(),
-                name
+                    .build()
             );
             return new Docker(container.id(), this);
         } catch (final DockerException | InterruptedException ex) {
             throw new IllegalStateException(
                 "Exception when creating the container "
-                + "with image: " + image + " & name: " + name, ex
+                + "with image: " + image, ex
             );
         }
     }

--- a/src/test/java/co/comdor/FireUpDockerTestCase.java
+++ b/src/test/java/co/comdor/FireUpDockerTestCase.java
@@ -55,7 +55,7 @@ public final class FireUpDockerTestCase {
         final Container container = Mockito.mock(Container.class);
         Mockito.when(container.start()).thenReturn(container);
         Mockito.when(host.connect()).thenReturn(host);
-        Mockito.when(host.create(Mockito.anyString(),Mockito.anyString()))
+        Mockito.when(host.create(Mockito.anyString()))
             .thenReturn(container);
 
         final Step fireup = new FireUpDocker(host, new Step.Fake(true));
@@ -90,7 +90,7 @@ public final class FireUpDockerTestCase {
         Mockito.doThrow(new IllegalStateException("Expected")).when(
                 container).execute(Mockito.anyString(), Mockito.any(Logger.class));
         Mockito.when(host.connect()).thenReturn(host);
-        Mockito.when(host.create(Mockito.anyString(),Mockito.anyString()))
+        Mockito.when(host.create(Mockito.anyString()))
                 .thenReturn(container);
 
         final Step fireup = new FireUpDocker(host, new Step.Fake(false));

--- a/src/test/java/co/comdor/RtDockerHostITCase.java
+++ b/src/test/java/co/comdor/RtDockerHostITCase.java
@@ -44,9 +44,7 @@ public class RtDockerHostITCase {
     @Test
     public void createsAndRemovesLocalContainer() throws Exception {
         final DockerHost host = new RtDockerHost().connect();
-        final Container created = host.create(
-            "hello-world", "test-local-container"
-        );
+        final Container created = host.create("hello-world");
         MatcherAssert.assertThat(created, Matchers.notNullValue());
         MatcherAssert.assertThat(created.isStarted(), Matchers.is(false));
         host.remove(created.containerId());

--- a/src/test/java/co/comdor/RtDockerHostTestCase.java
+++ b/src/test/java/co/comdor/RtDockerHostTestCase.java
@@ -46,7 +46,7 @@ public final class RtDockerHostTestCase {
     public void cannotCreateIfNotConnected() throws Exception {
         final DockerHost host = new RtDockerHost();
         try {
-            host.create("test/test", "name");
+            host.create("test/test");
         } catch (final IllegalStateException ex) {
             MatcherAssert.assertThat(
                 ex.getMessage(), Matchers.startsWith("Not connected.")


### PR DESCRIPTION
Fixes #73 
We don't provide the name for the containers, for now, it makes no sense.