### PR TITLE
Docker start + docker logs

### DIFF
--- a/src/main/java/co/comdor/Container.java
+++ b/src/main/java/co/comdor/Container.java
@@ -25,6 +25,8 @@
  */
 package co.comdor;
 
+import org.slf4j.Logger;
+
 /**
  * A container where the scripts are run.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -37,7 +39,13 @@ public interface Container extends AutoCloseable {
      * Start this container.
      */
     void start();
-    
+
+    /**
+     * Fetch the logs of this container.
+     * @param logger Logger used to register the container's logs.
+     */
+    void fetchLogs(final Logger logger);
+
     @Override
     void close();
     

--- a/src/main/java/co/comdor/Docker.java
+++ b/src/main/java/co/comdor/Docker.java
@@ -25,6 +25,8 @@
  */
 package co.comdor;
 
+import org.slf4j.Logger;
+
 /**
  * A Docker container where the scripts are run.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -75,6 +77,11 @@ public final class Docker implements Container {
     public void start() {
         this.docker.start(this.id);
         this.started = true;
+    }
+
+    @Override
+    public void fetchLogs(final Logger logger) {
+        this.docker.followLogs(this.id, logger);
     }
 
     @Override

--- a/src/main/java/co/comdor/DockerHost.java
+++ b/src/main/java/co/comdor/DockerHost.java
@@ -26,6 +26,7 @@
 package co.comdor;
 
 import java.io.IOException;
+import org.slf4j.Logger;
 
 /**
  * The Docker host where comdor runs the containers.
@@ -56,6 +57,13 @@ public interface DockerHost {
      * @param containterId The container's id.
      */
     void start(final String containterId);
+
+    /**
+     * Follow a container's logs.
+     * @param containerId The container's id.
+     * @param logger Logger to record the output into.
+     */
+    void followLogs(final String containerId, final Logger logger);
 
     /**
      * Kill a container.

--- a/src/main/java/co/comdor/FireUpDocker.java
+++ b/src/main/java/co/comdor/FireUpDocker.java
@@ -86,6 +86,7 @@ public final class FireUpDocker extends IntermediaryStep {
                 );
         ) {
             container.start();
+            container.fetchLogs(log.logger());
         }
         this.next().perform(command, log);
     }

--- a/src/main/java/co/comdor/RtDockerHost.java
+++ b/src/main/java/co/comdor/RtDockerHost.java
@@ -28,10 +28,13 @@ package co.comdor;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerCertificates;
 import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.LogStream;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
+import org.slf4j.Logger;
+
 import java.io.IOException;
 import java.nio.file.Paths;
 
@@ -154,7 +157,6 @@ public final class RtDockerHost implements DockerHost{
                 + "instance by calling #connect()"
             );
         }
-
         try {
             this.client.startContainer(containerId);
         } catch (final DockerException | InterruptedException ex) {
@@ -162,6 +164,31 @@ public final class RtDockerHost implements DockerHost{
                 "Exception when starting container with id " + containerId, ex
             );
         }
+    }
+
+    @Override
+    public void followLogs(final String containerId, final Logger logger) {
+        if(this.client == null) {
+            throw new IllegalStateException(
+                "Not connected. Don't forget to get a connected "
+                + "instance by calling #connect()"
+            );
+        }
+        logger.info("********** Container logs **********");
+        try {
+            final LogStream logs = this.client.logs(
+                containerId,
+                DockerClient.LogsParam.stdout(),
+                DockerClient.LogsParam.stderr(),
+                DockerClient.LogsParam.follow()
+            );
+            logger.info(logs.readFully());
+        } catch (final DockerException | InterruptedException ex) {
+            throw new IllegalStateException(
+                "Exception when starting container with id " + containerId, ex
+            );
+        }
+        logger.info("************************************");
     }
 
     @Override


### PR DESCRIPTION
Fixes #78 #77 
Since ``follow logs`` waits for the Docker container to execute, it is ok if it remains Closeable. 